### PR TITLE
[AETHER-1265] Integrate Java profiler in TOST env

### DIFF
--- a/atomix/Chart.yaml
+++ b/atomix/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: atomix
-version: 0.1.5
+version: 0.1.6
 kubeVersion: ">=1.10.0"
 appVersion: 3.1.9
 description: Configurable Atomix 3.1.9 cluster

--- a/atomix/templates/nodeports.yaml
+++ b/atomix/templates/nodeports.yaml
@@ -1,5 +1,5 @@
 # Sometimes, it is very hard monitoring or taking the snapshots through the proxy
-{{- if .Values.profiler.enabled }}
+{{- if .Values.profiler.exposeNodePort }}
 {{- $root := . -}}
 {{ range $k, $index := until (atoi (quote .Values.replicas) | default 3) }}
 ---

--- a/atomix/templates/nodeports.yaml
+++ b/atomix/templates/nodeports.yaml
@@ -1,0 +1,19 @@
+# Sometimes, it is very hard monitoring or taking the snapshots through the proxy
+{{- if .Values.profiler.enabled }}
+{{- $root := . -}}
+{{ range $k, $index := until (atoi (quote .Values.replicas) | default 3) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: atomix-profiler-{{ $index }}
+spec:
+  type: NodePort
+  ports:
+    - name: atomix-profiler-{{ $index }}
+      port: 10001
+      nodePort: {{ add $index 31001 }}
+  selector:
+      statefulset.kubernetes.io/pod-name: {{ template "fullname" $ }}-{{ $index }}
+{{ end }}
+{{- end}}

--- a/atomix/values.yaml
+++ b/atomix/values.yaml
@@ -39,7 +39,7 @@ ingress:
 # Adds an additional nodeport to allow profiler connection.
 # When false, profiler can still connect through proxy/port-forward
 profiler:
-  enabled: false
+  exposeNodePort: false
 
 podAntiAffinity:
   enabled: true

--- a/atomix/values.yaml
+++ b/atomix/values.yaml
@@ -36,6 +36,11 @@ config: |
 ingress:
   enabled: false
 
+# Adds an additional nodeport to allow profiler connection.
+# When false, profiler can still connect through proxy/port-forward
+profiler:
+  enabled: false
+
 podAntiAffinity:
   enabled: true
 


### PR DESCRIPTION
Add a nodeport for each atomix instance to enable the connection between client and profiler agent.